### PR TITLE
[codex] restore `ProseMirror-selectednode` with selection hook

### DIFF
--- a/.changeset/khaki-doors-join.md
+++ b/.changeset/khaki-doors-join.md
@@ -1,0 +1,11 @@
+---
+'@prosemirror-adapter/core': patch
+'@prosemirror-adapter/lit': patch
+'@prosemirror-adapter/preact': patch
+'@prosemirror-adapter/react': patch
+'@prosemirror-adapter/solid': patch
+'@prosemirror-adapter/svelte': patch
+'@prosemirror-adapter/vue': patch
+---
+
+Restore ProseMirror's default selected-node class and draggable behavior for node views without custom select handlers.

--- a/e2e/src/shared/createEditorView.ts
+++ b/e2e/src/shared/createEditorView.ts
@@ -6,7 +6,7 @@ import { exampleSetup } from 'prosemirror-example-setup'
 import { keymap } from 'prosemirror-keymap'
 import { schema } from 'prosemirror-schema-basic'
 import type { Plugin } from 'prosemirror-state'
-import { EditorState } from 'prosemirror-state'
+import { EditorState, NodeSelection, TextSelection } from 'prosemirror-state'
 import type { MarkViewConstructor, NodeViewConstructor } from 'prosemirror-view'
 import { EditorView } from 'prosemirror-view'
 
@@ -143,7 +143,7 @@ export function createEditorView(
   markViews: Record<string, MarkViewConstructor>,
   plugins: Plugin[],
 ) {
-  return new EditorView(element, {
+  const view = new EditorView(element, {
     state: EditorState.create({
       doc: schema.nodeFromJSON(defaultDoc),
       schema,
@@ -174,4 +174,43 @@ export function createEditorView(
     nodeViews,
     markViews,
   })
+
+  installTestHelpers(view)
+
+  return view
+}
+
+type TestWindow = Window & {
+  __selectNodeByType?: (typeName: string, index?: number) => void
+  __setTextSelection?: (pos?: number) => void
+}
+
+function installTestHelpers(view: EditorView) {
+  const testWindow = window as TestWindow
+
+  testWindow.__selectNodeByType = (typeName, index = 0) => {
+    let foundPos: number | undefined
+    let remaining = index
+
+    view.state.doc.descendants((node, pos) => {
+      if (foundPos != null) return false
+      if (node.type.name !== typeName) return true
+      if (remaining > 0) {
+        remaining -= 1
+        return true
+      }
+      foundPos = pos
+      return false
+    })
+
+    if (foundPos == null) {
+      throw new Error(`Cannot find node of type "${typeName}" at index ${index}`)
+    }
+
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, foundPos)))
+  }
+
+  testWindow.__setTextSelection = (pos = 1) => {
+    view.dispatch(view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(pos), 1)))
+  }
 }

--- a/e2e/tests/node-view.spec.ts
+++ b/e2e/tests/node-view.spec.ts
@@ -40,4 +40,23 @@ testAll(() => {
     await expect(h4).not.toBeVisible()
     await expect(h5).toBeVisible()
   })
+
+  test('node selection applies ProseMirror default selected node behavior', async ({ page }) => {
+    const headingNodeView = page.locator('.editor [data-node-view-root="true"]').first()
+    await expect(headingNodeView).toBeVisible()
+
+    await page.evaluate(() => {
+      ;(window as unknown as { __selectNodeByType: (typeName: string) => void }).__selectNodeByType('heading')
+    })
+
+    await expect(headingNodeView).toHaveClass(/ProseMirror-selectednode/)
+    await expect(headingNodeView).toHaveAttribute('draggable', 'true')
+
+    await page.evaluate(() => {
+      ;(window as unknown as { __setTextSelection: () => void }).__setTextSelection()
+    })
+
+    await expect(headingNodeView).not.toHaveClass(/ProseMirror-selectednode/)
+    await expect(headingNodeView).not.toHaveAttribute('draggable', 'true')
+  })
 })

--- a/packages/core/src/nodeView/CoreNodeView.ts
+++ b/packages/core/src/nodeView/CoreNodeView.ts
@@ -73,12 +73,30 @@ export class CoreNodeView<ComponentType> implements NodeView {
 
   selectNode = () => {
     this.selected = true
-    this.options.selectNode?.()
+    if (this.options.selectNode) this.options.selectNode()
+    else this.selectNodeDefault()
+    this.options.onSelectionChange?.()
   }
 
   deselectNode = () => {
     this.selected = false
-    this.options.deselectNode?.()
+    if (this.options.deselectNode) this.options.deselectNode()
+    else this.deselectNodeDefault()
+    this.options.onSelectionChange?.()
+  }
+
+  protected selectNodeDefault = () => {
+    this.dom.classList.add('ProseMirror-selectednode')
+    if (this.contentDOM || !this.node.type.spec.draggable) {
+      this.dom.draggable = true
+    }
+  }
+
+  protected deselectNodeDefault = () => {
+    this.dom.classList.remove('ProseMirror-selectednode')
+    if (this.contentDOM || !this.node.type.spec.draggable) {
+      this.dom.removeAttribute('draggable')
+    }
   }
 
   // Return true if the current node view instance can handle the update.

--- a/packages/core/src/nodeView/CoreNodeView.ts
+++ b/packages/core/src/nodeView/CoreNodeView.ts
@@ -85,6 +85,9 @@ export class CoreNodeView<ComponentType> implements NodeView {
     this.options.onSelectionChange?.()
   }
 
+  // Restore ProseMirror's default selected-node marking when users don't
+  // provide custom select handlers:
+  // https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/tag/1.42.0/src/viewdesc.ts#L890
   protected selectNodeDefault = () => {
     this.dom.classList.add('ProseMirror-selectednode')
     if (this.contentDOM || !this.node.type.spec.draggable) {

--- a/packages/core/src/nodeView/CoreNodeViewOptions.ts
+++ b/packages/core/src/nodeView/CoreNodeViewOptions.ts
@@ -22,6 +22,7 @@ export interface CoreNodeViewUserOptions<Component> {
 
   // Additional
   onUpdate?: () => void
+  onSelectionChange?: () => void
 }
 
 export interface CoreNodeViewSpec<Component> {

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -415,6 +415,8 @@ interface NodeViewFactoryOptions {
 
   // Called when the node view is updated.
   onUpdate?: () => void
+  // Called after the node view is selected or deselected.
+  onSelectionChange?: () => void
 }
 ```
 

--- a/packages/lit/src/nodeView/useLitNodeViewCreator.ts
+++ b/packages/lit/src/nodeView/useLitNodeViewCreator.ts
@@ -20,12 +20,8 @@ export function useLitNodeViewCreator(
           options.onUpdate?.()
           nodeView.updateContext()
         },
-        selectNode() {
-          options.selectNode?.()
-          nodeView.updateContext()
-        },
-        deselectNode() {
-          options.deselectNode?.()
+        onSelectionChange() {
+          options.onSelectionChange?.()
           nodeView.updateContext()
         },
         destroy() {

--- a/packages/preact/src/nodeView/usePreactNodeViewCreator.ts
+++ b/packages/preact/src/nodeView/usePreactNodeViewCreator.ts
@@ -23,12 +23,8 @@ export function buildPreactNodeViewCreator<ComponentType>(
           userOptions.onUpdate?.()
           renderPreactRenderer(nodeView)
         },
-        selectNode() {
-          userOptions.selectNode?.()
-          renderPreactRenderer(nodeView)
-        },
-        deselectNode() {
-          userOptions.deselectNode?.()
+        onSelectionChange() {
+          userOptions.onSelectionChange?.()
           renderPreactRenderer(nodeView)
         },
         destroy() {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -377,6 +377,8 @@ interface NodeViewFactoryOptions {
 
   // Called when the node view is updated.
   onUpdate?: () => void
+  // Called after the node view is selected or deselected.
+  onSelectionChange?: () => void
 }
 ```
 

--- a/packages/react/src/nodeView/useReactNodeViewCreator.ts
+++ b/packages/react/src/nodeView/useReactNodeViewCreator.ts
@@ -23,12 +23,8 @@ export function buildReactNodeViewCreator<ComponentType>(
           userOptions.onUpdate?.()
           renderReactRenderer(nodeView)
         },
-        selectNode() {
-          userOptions.selectNode?.()
-          renderReactRenderer(nodeView)
-        },
-        deselectNode() {
-          userOptions.deselectNode?.()
+        onSelectionChange() {
+          userOptions.onSelectionChange?.()
           renderReactRenderer(nodeView)
         },
         destroy() {

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -370,6 +370,8 @@ interface NodeViewFactoryOptions {
 
   // Called when the node view is updated.
   onUpdate?: () => void
+  // Called after the node view is selected or deselected.
+  onSelectionChange?: () => void
 }
 ```
 

--- a/packages/solid/src/nodeView/useSolidNodeViewCreator.ts
+++ b/packages/solid/src/nodeView/useSolidNodeViewCreator.ts
@@ -22,12 +22,8 @@ export function buildSolidNodeViewCreator<ComponentType>(
           userOptions.onUpdate?.()
           nodeView.updateContext()
         },
-        selectNode() {
-          userOptions.selectNode?.()
-          nodeView.updateContext()
-        },
-        deselectNode() {
-          userOptions.deselectNode?.()
+        onSelectionChange() {
+          userOptions.onSelectionChange?.()
           nodeView.updateContext()
         },
         destroy() {

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -368,6 +368,8 @@ interface NodeViewFactoryOptions {
 
   // Called when the node view is updated.
   onUpdate?: () => void
+  // Called after the node view is selected or deselected.
+  onSelectionChange?: () => void
 }
 ```
 

--- a/packages/svelte/src/nodeView/useSvelteNodeViewCreator.ts
+++ b/packages/svelte/src/nodeView/useSvelteNodeViewCreator.ts
@@ -24,12 +24,8 @@ export function buildSvelteNodeViewCreator<ComponentType>(
           userOptions.onUpdate?.()
           nodeView.updateContext()
         },
-        selectNode() {
-          userOptions.selectNode?.()
-          nodeView.updateContext()
-        },
-        deselectNode() {
-          userOptions.deselectNode?.()
+        onSelectionChange() {
+          userOptions.onSelectionChange?.()
           nodeView.updateContext()
         },
         destroy() {

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -399,6 +399,8 @@ interface NodeViewFactoryOptions {
 
   // Called when the node view is updated.
   onUpdate?: () => void
+  // Called after the node view is selected or deselected.
+  onSelectionChange?: () => void
 }
 ```
 

--- a/packages/vue/src/nodeView/useVueNodeViewCreator.ts
+++ b/packages/vue/src/nodeView/useVueNodeViewCreator.ts
@@ -22,12 +22,8 @@ export function buildVueNodeViewCreator<ComponentType>(
           userOptions.onUpdate?.()
           nodeView.updateContext()
         },
-        selectNode() {
-          userOptions.selectNode?.()
-          nodeView.updateContext()
-        },
-        deselectNode() {
-          userOptions.deselectNode?.()
+        onSelectionChange() {
+          userOptions.onSelectionChange?.()
           nodeView.updateContext()
         },
         destroy() {


### PR DESCRIPTION
## Summary

- Restore ProseMirror's default selected-node class and `draggable` behavior in `CoreNodeView` when no custom select handlers are provided.
- Add `onSelectionChange` as a post-select/deselect hook so framework adapters can refresh context without replacing `nodeView.selectNode` or `nodeView.deselectNode`.
- Keep user-provided `selectNode` and `deselectNode` wired directly through the normal options path.
- Add e2e coverage for `.ProseMirror-selectednode` and `draggable` toggling across Lit, Preact, React, Solid, Svelte, and Vue examples.
- Add a patch changeset and document the new node-view option.

## Root Cause

Framework adapters installed internal `selectNode` and `deselectNode` callbacks to rerender selected state. `prosemirror-view` treats those callbacks as custom node-view overrides, so its default selected-node behavior never ran for adapter node views.

This version keeps those override slots reserved for user-provided handlers and moves framework context refreshes into `onSelectionChange`, which runs after `selectNode` or `deselectNode` completes.

## Checks

- `pnpm run build`
- `pnpm --filter=e2e test tests/node-view.spec.ts --project=chromium`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
