### PR TITLE
fix(core): report `contentDOM` replacement mutations

### DIFF
--- a/.changeset/tender-spoons-report.md
+++ b/.changeset/tender-spoons-report.md
@@ -1,0 +1,5 @@
+---
+'@prosemirror-adapter/core': patch
+---
+
+Report replacement mutations after the browser removes a node view's `contentDOM`, allowing ProseMirror to preserve the first character typed over a full selection.

--- a/e2e/tests/node-view.spec.ts
+++ b/e2e/tests/node-view.spec.ts
@@ -42,14 +42,15 @@ testAll(() => {
   })
 })
 
-testAll(() => {
+testAll(({ framework }) => {
   test('code block node view preserves the first character typed over a full selection', async ({
     page,
     browserName,
   }) => {
     test.fail(
-      browserName === 'chromium' || browserName === 'webkit',
-      'prosemirror-view currently drops the first character in these browsers',
+      // https://code.haverbeke.berlin/prosemirror/prosemirror/issues/1581
+      framework === 'lit' && (browserName === 'chromium' || browserName === 'webkit'),
+      'prosemirror-view cannot recover Lit node view content in these browsers',
     )
 
     const content = page.locator('.editor [data-node-view-root="true"] pre code[data-node-view-content="true"]')

--- a/packages/core/src/nodeView/CoreNodeView.ts
+++ b/packages/core/src/nodeView/CoreNodeView.ts
@@ -8,6 +8,8 @@ import { isContentDOMRemoval } from '../utils/is-content-dom-removal'
 import type { CoreNodeViewSpec, CoreNodeViewUserOptions, NodeViewDOMSpec } from './CoreNodeViewOptions'
 
 export class CoreNodeView<ComponentType> implements NodeView {
+  #contentDOMWasRemoved = false
+
   key: string
   dom: HTMLElement
   contentDOM: HTMLElement | null
@@ -107,6 +109,8 @@ export class CoreNodeView<ComponentType> implements NodeView {
   shouldIgnoreMutation: (mutation: ViewMutationRecord) => boolean = (mutation) => {
     if (!this.dom || !this.contentDOM) return true
 
+    if (this.dom.contains(this.contentDOM)) this.#contentDOMWasRemoved = false
+
     if (this.node.isLeaf || this.node.isAtom) return true
 
     if (mutation.type === 'selection') return false
@@ -115,7 +119,12 @@ export class CoreNodeView<ComponentType> implements NodeView {
 
     if (this.contentDOM.contains(mutation.target)) return false
 
-    if (isContentDOMRemoval(mutation, this.contentDOM)) return false
+    if (isContentDOMRemoval(mutation, this.contentDOM)) {
+      this.#contentDOMWasRemoved = true
+      return false
+    }
+
+    if (this.#contentDOMWasRemoved && this.dom.contains(mutation.target)) return false
 
     return true
   }


### PR DESCRIPTION
## What

- Track when the browser removes a node view's `contentDOM`.
- Report subsequent replacement mutations until `contentDOM` is restored, so ProseMirror can preserve the first typed character.
- Keep Lit on Chromium and WebKit as expected failures because [prosemirror/prosemirror#1581](https://code.haverbeke.berlin/prosemirror/prosemirror/issues/1581) requires an upstream fix.
- Add a patch changeset for `@prosemirror-adapter/core`.

## Why

After the browser removes `contentDOM`, the adapter reports that removal but ignores the following replacement mutations because their targets are no longer inside the detached `contentDOM`. ProseMirror therefore never sees the newly typed content.

This change keeps reporting mutations inside the node view until `contentDOM` is restored. It fixes the regression for Preact, React, Solid, Svelte, and Vue. Lit still exposes an upstream `prosemirror-view` content-element recovery problem.

## Validation

- `pnpm fix`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- Targeted Playwright matrix: 16 regular passes and 2 expected Lit failures, reported as 18 passed
